### PR TITLE
[FIX!] 클립보드 관찰해서 자동으로 들어온 데이터,기록보기 UI에 안 뜨는 버그 수정

### DIFF
--- a/ccd-main/clipboard/index.js
+++ b/ccd-main/clipboard/index.js
@@ -93,6 +93,12 @@ function startMonitoring() {
       );
 
       payload.id = newItem?.id;
+
+      // 🟡 중요: 렌더러에 "새 클립보드 항목이 추가됨"을 알림
+      notifyRenderer("clipboard-updated", {
+        id: newItem?.id ?? payload.id,
+      });
+
     } catch (err) {
       const error = CCDError.create("E630", {
         module: "index",

--- a/ccd-main/preload.js
+++ b/ccd-main/preload.js
@@ -31,7 +31,12 @@ contextBridge.exposeInMainWorld("electronAPI", {
   // 붙여넣기
   pasteItem: (itemId) =>
     ipcRenderer.invoke("paste-item", { itemId }),
+  //클립보드의 실시간 업데이트되는 데이터
+  onClipboardUpdated: (callback) =>
+    ipcRenderer.on("clipboard-updated", (_, args) => callback(args)),
 
+  offClipboardUpdated: (callback) =>
+    ipcRenderer.removeListener("clipboard-updated", callback),
   // 검색
   searchKeyword: (keyword, model) =>
     ipcRenderer.invoke("search-keyword", { keyword, model }),

--- a/ccd-renderer/src/feature/Login/LoginModal.jsx
+++ b/ccd-renderer/src/feature/Login/LoginModal.jsx
@@ -227,7 +227,7 @@ const [pwError, setPwError] = useState("");
                 <div className="flex flex-row">
                   <input
                     type="text"
-                    maxLength={8}
+                    maxLength={20}
                     placeholder="ID"
                     value={userId}
                     onChange={(e) => handleIDChange(e.target.value)}
@@ -250,7 +250,7 @@ const [pwError, setPwError] = useState("");
                       type="password"
                       placeholder="PW"
                       value={pw}
-                      maxLength={8}
+                      maxLength={20}
                       onChange={(e) => handlePwChange(e.target.value)}
                       className="!w-[8.3rem] px-2 py-1 ml-[0.2rem] rounded-md bg-gray-100 text-gray-800"
                     />
@@ -368,7 +368,7 @@ const [pwError, setPwError] = useState("");
                   ID
                   <input
                     type="text"
-                    maxLength={8}
+                    maxLength={20}
                     placeholder="ID"
                     onChange={(e) => setUserId(e.target.value)}
                     className="!w-[8.3rem]  px-2 py-1 ml-[0.917rem] rounded-md bg-gray-100 text-gray-800 flex-1"
@@ -387,7 +387,7 @@ const [pwError, setPwError] = useState("");
                   <input
                     type="password"
                     placeholder="PW"  
-                    maxLength={8}    
+                    maxLength={20}
                     onChange={(e) => setPw(e.target.value)}             
                     className="!w-[8.3rem] ml-2 px-2 py-1 ml-[0.2rem] rounded-md bg-gray-100 text-gray-800 flex-1"
                   />

--- a/ccd-renderer/src/feature/MainView/MainView.jsx
+++ b/ccd-renderer/src/feature/MainView/MainView.jsx
@@ -5,10 +5,11 @@ import "../../styles/color.css";
 import useClipboardRecords from '../../utils/useClipboardRecords';
 
 
-const MainView = ({isTagChecked,refetch, items, toggleSelect,addItem }) => {
+const MainView = ({isTagChecked}) => {
   // const [items, setItems] = useState([]);
   const [activeItemId, setActiveItemId] = useState(null);
   const containerRefs = useRef({});
+  const { items, refetch, toggleSelect, addItem } = useClipboardRecords();
 
   // 모달 외부 클릭 시 닫기
   useEffect(() => {


### PR DESCRIPTION
## PR 내용
- 버그의 핵심은, 메인프로세스에서 실시간 클립보드 감지는 하는데 렌더러의 기록보기에 갱신 요청 ipc통신을 하지 않아서 였음.
- 이에 메인 프로세스에 관련 ipc 통신 모듈을 덧붙임. 메인프로세스 담당자 (@parang55 ,@rayeonghur)들은 꼭 코드 확인 바람

### 기타
- 지나치게 까다로운 기록보기창의 렌더링 로직을 완화하였음. tag 등이 비어있어도 화면에 정상적으로 나타나게 수정함.
- 요구사항에 맞춰, 회원가입/로그인 글자수 제한을 20자로 확대함. 